### PR TITLE
bug fix for issue 1 (extra space at end of textToMorse output

### DIFF
--- a/MorseCode.js
+++ b/MorseCode.js
@@ -64,7 +64,7 @@ function MorseCode(){
                 }
             })
         
-        return results;
+        return results.trim();
     }
 
     function morseToText(txtMorse){


### PR DESCRIPTION
added .trim() to remove extra space at beginning & end of string before returning it